### PR TITLE
Add cloud support support for Kubescape

### DIFF
--- a/charts/armo-components/templates/_helpers.tpl
+++ b/charts/armo-components/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{/* standardize cloud provider */}}
+{{- define "cloud_provider" -}}
+  {{- if .Values.cloud_provider_engine -}}
+    {{- $provider := lower .Values.cloud_provider_engine -}}
+    {{- if or (contains "eks" $provider) (contains "aws" $provider) (contains "amazon" $provider) -}}
+eks
+    {{- else if or (contains "gke" $provider) (contains "gcp" $provider) (contains "google" $provider) -}}
+gke
+    {{- end -}}
+  {{- end -}}
+{{- end }}

--- a/charts/armo-components/templates/armo-kubescape-cronjob.yaml
+++ b/charts/armo-components/templates/armo-kubescape-cronjob.yaml
@@ -1,3 +1,4 @@
+{{- $cloud_provider := (include "cloud_provider" .) -}}
 {{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
 apiVersion: batch/v1
 {{- else if .Capabilities.APIVersions.Has "batch/v1beta1/CronJob" }}
@@ -28,6 +29,18 @@ spec:
               value: "{{ .Values.armoKubescape.name }}-config"
             - name: KS_DEFAULT_CONFIGMAP_NAMESPACE
               value: "{{ .Values.armoNameSpace }}"
+            {{- if $cloud_provider }}
+            - name: KS_CLOUD_PROVIDER
+              value: "{{ $cloud_provider }}"
+            - name: KS_CLOUD_REGION
+              value: "{{ .Values.cloudRegion }}"
+            - name: KS_KUBE_CLUSTER
+              value: "{{ .Values.clusterName }}"
+            {{- if eq "gke" $cloud_provider }}
+            - name: KS_GKE_PROJECT
+              value: "{{ .Values.gkeProject }}"
+            {{- end -}}
+            {{- end }}
             args: 
             - kubescape scan --submit {{ if eq .Values.environment "dev" }}--environment=dev{{ end }}
             resources:

--- a/charts/armo-components/templates/armo-kubescape-job.yaml
+++ b/charts/armo-components/templates/armo-kubescape-job.yaml
@@ -1,3 +1,4 @@
+{{- $cloud_provider := (include "cloud_provider" .) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -23,6 +24,18 @@ spec:
           value: "{{ .Values.armoKubescape.name }}-config"
         - name: KS_DEFAULT_CONFIGMAP_NAMESPACE
           value: "{{ .Values.armoNameSpace }}"
+        {{- if $cloud_provider }}
+        - name: KS_CLOUD_PROVIDER
+          value: "{{ $cloud_provider }}"
+        - name: KS_CLOUD_REGION
+          value: "{{ .Values.cloudRegion }}"
+        - name: KS_KUBE_CLUSTER
+          value: "{{ .Values.clusterName }}"
+        {{- if eq "gke" $cloud_provider }}
+        - name: KS_GKE_PROJECT
+          value: "{{ .Values.gkeProject }}"
+        {{- end -}}
+        {{- end }}
         args: 
         - kubescape scan --submit {{ if eq .Values.environment "dev" }}--environment=dev{{ end }}
         resources:

--- a/charts/armo-components/templates/armo-kubescape-service-account.yaml
+++ b/charts/armo-components/templates/armo-kubescape-service-account.yaml
@@ -1,7 +1,17 @@
+{{- if .Values.createKubescapeServiceAccount -}}
+{{- $cloud_provider := (include "cloud_provider" .) -}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+{{- if .Values.aws_iam_role_arn }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.aws_iam_role_arn }}
+  {{- else if .Values.gke_service_account }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ .Values.gke_service_account }}
+{{- end }}
   labels:
     app: {{ .Values.appLabel }}
   name: {{ .Values.global.armoKubescapeServiceAccountName }}
   namespace: {{ .Values.armoNameSpace }}
+{{- end -}}

--- a/charts/armo-components/values.yaml
+++ b/charts/armo-components/values.yaml
@@ -22,8 +22,11 @@ accountGuid : "1e3a88bf-92ce-44f8-914e-000000000000"
 clusterName: "kubescape-default-cluster-name"
 
 # Cloud support
+cloud_provider_engine:
+cloudRegion:
 aws_iam_role_arn:
 gke_service_account:
+gkeProject:
 
 loginInfo:
   username: ""

--- a/charts/armo-components/values.yaml
+++ b/charts/armo-components/values.yaml
@@ -6,7 +6,7 @@ armoNameSpace: armo-system
 appLabel: armo-vuln-scanner
 registrySecretName: armoregcred
 loginSecretName: armo-login
-
+createKubescapeServiceAccount: true
 
 # ARMO BE URLs
 environment: "prod"
@@ -21,6 +21,9 @@ devK8sReportUrl: "wss://report.eudev3.cyberarmorsoft.com"
 accountGuid : "1e3a88bf-92ce-44f8-914e-000000000000"
 clusterName: "kubescape-default-cluster-name"
 
+# Cloud support
+aws_iam_role_arn:
+gke_service_account:
 
 loginInfo:
   username: ""


### PR DESCRIPTION
Feature/cloudsupport

The PR is about adding cloud support, AWS, and GCP, for Kubescape running as a job in Kubernetes.
It modifies the service account template, the values, the env section of the job and cronjob templates, and a named function.

