### PR TITLE
expose port 8080 on kubescape deployment to service

### DIFF
--- a/charts/armo-components/templates/armo-kubescape-deployment.yaml
+++ b/charts/armo-components/templates/armo-kubescape-deployment.yaml
@@ -28,6 +28,10 @@ spec:
       - name: kubescape
         image: "{{ .Values.armoKubescape.image.repository }}:{{ .Values.armoKubescape.image.tag }}"
         imagePullPolicy: "{{ .Values.armoKubescape.image.pullPolicy }}"
+        ports:
+          - name: http
+            containerPort: 8080
+            protocol: TCP
         livenessProbe:
           httpGet:
             path: /livez

--- a/charts/armo-components/templates/armo-kubescape-service.yaml
+++ b/charts/armo-components/templates/armo-kubescape-service.yaml
@@ -8,8 +8,9 @@ metadata:
 spec:
   type: {{ .Values.armoKubescape.service.type }}
   ports:
-    - port: {{ .Values.armoKubescape.service.port }}
-      targetPort: {{ .Values.armoKubescape.service.targetPort }}
-      protocol: {{ .Values.armoKubescape.service.protocol }}
+    - name: http
+      port: {{ .Values.armoKubescape.service.port }}
+      targetPort: 8080
+      protocol: TCP
   selector:
     app: {{ .Values.armoKubescape.name }}

--- a/charts/armo-components/values.yaml
+++ b/charts/armo-components/values.yaml
@@ -147,8 +147,6 @@ armoKubescape:
   service:
     type: ClusterIP
     port: 8080
-    targetPort: 8080
-    protocol: TCP
 
 armoWebsocket:
 


### PR DESCRIPTION
Currently the kubescape deployment does not expose port 8080 and thus services like e.g. prometheus using serviceMonitors are not able to communicate with the pod. The PR exposes port 8080, assigns a name and re-configures the service to use this port as targetPort, and adjusts the variables for the service port.