### PR TITLE
Add a prometheus service monitor for kubescape pod

### DIFF
--- a/charts/armo-components/templates/armo-kubescape-servicemonitor.yaml
+++ b/charts/armo-components/templates/armo-kubescape-servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{ if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.armoKubescape.name }}-monitor
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ .Values.armoKubescape.name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  namespaceSelector:
+    matchNames:
+      -  {{ .Values.armoNameSpace }}
+  selector:
+    matchLabels:
+      app: {{ .Values.armoKubescape.name }}
+  endpoints:
+    - port: http
+      path: /v1/metrics
+      interval: 120s
+      scrapeTimeout: 100s
+{{ end }}

--- a/charts/armo-components/templates/armo-kubescape-servicemonitor.yaml
+++ b/charts/armo-components/templates/armo-kubescape-servicemonitor.yaml
@@ -1,10 +1,10 @@
-{{ if .Values.serviceMonitor.enabled }}
+{{ if .Values.armoKubescape.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ .Values.armoKubescape.name }}-monitor
-  {{- if .Values.serviceMonitor.namespace }}
-  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- if .Values.armoKubescape.serviceMonitor.namespace }}
+  namespace: {{ .Values.armoKubescape.serviceMonitor.namespace }}
   {{- end }}
   labels:
     app: {{ .Values.armoKubescape.name }}

--- a/charts/armo-components/values.yaml
+++ b/charts/armo-components/values.yaml
@@ -152,7 +152,7 @@ armoKubescape:
 
   # Deploy a service monitor for prometheus (operator) integreation
   serviceMonitor:
-    enabled: true
+    enabled: false
     # If needed the servicemonitor can be deployed to a different namespace than the one armoKubescape is in
     #namespace: my-namespace
 

--- a/charts/armo-components/values.yaml
+++ b/charts/armo-components/values.yaml
@@ -150,6 +150,12 @@ armoKubescape:
     type: ClusterIP
     port: 8080
 
+  # Deploy a service monitor for prometheus (operator) integreation
+  serviceMonitor:
+    enabled: true
+    # If needed the servicemonitor can be deployed to a different namespace than the one armoKubescape is in
+    #namespace: my-namespace
+
 armoWebsocket:
 
   ## Deploy WebSocket


### PR DESCRIPTION
Adds a service monitor resource that lets the kubescape pod be discovered as target by prometheus