### PR TITLE
helm chart should be deployable without setting an accountGuid

### DIFF
--- a/charts/armo-components/templates/_helpers.tpl
+++ b/charts/armo-components/templates/_helpers.tpl
@@ -11,10 +11,12 @@ gke
 {{- end }}
 
 {{- define "account_guid" -}}
-  {{- if .Values.accountGuid -}}
-  {{- else -}}
-    {{- fail "value for accountGuid is not defined: please register at https://portal.armo.cloud to get yours and re-run with  --set accountGuid=<your Guid>" }}
-  {{- end -}}
+  {{- if .Values.armoKubescape.submit }}
+    {{- if .Values.accountGuid) -}}
+    {{- else -}}
+      {{- fail "submitting is enabled but value for accountGuid is not defined: please register at https://portal.armo.cloud to get yours and re-run with  --set accountGuid=<your Guid>" }}
+    {{- end -}}
+  {{- end }}
 {{- end }}
 
 {{- define "cluster_name" -}}

--- a/charts/armo-components/templates/_helpers.tpl
+++ b/charts/armo-components/templates/_helpers.tpl
@@ -12,11 +12,12 @@ gke
 
 {{- define "account_guid" -}}
   {{- if .Values.armoKubescape.submit }}
-    {{- if .Values.accountGuid) -}}
+    {{- if .Values.accountGuid -}}
     {{- else -}}
       {{- fail "submitting is enabled but value for accountGuid is not defined: please register at https://portal.armo.cloud to get yours and re-run with  --set accountGuid=<your Guid>" }}
     {{- end -}}
   {{- end }}
+  {{- if .Values.accountGuid -}} {{ .Values.accountGuid | quote }} {{- else -}} "" {{- end }}
 {{- end }}
 
 {{- define "cluster_name" -}}

--- a/charts/armo-components/templates/armo-collector-deployment.yaml
+++ b/charts/armo-components/templates/armo-collector-deployment.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.armoCollector.enabled  }}
-{{ template "account_guid" . }}
+{{- if and .Values.armoCollector.enabled .Values.accountGuid }}
 {{ template "cluster_name" . }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/armo-components/templates/armo-configmap.yaml
+++ b/charts/armo-components/templates/armo-configmap.yaml
@@ -1,4 +1,3 @@
-{{ template "account_guid" . }}
 {{ template "cluster_name" . }}
 kind: ConfigMap 
 apiVersion: v1 
@@ -40,7 +39,7 @@ data:
       "masterNotificationServer": "wss://{{ .Values.masterNotificationService }}/v1/waitfornotification",
 {{- end }}       
       "portal": "",
-      "customerGUID": "{{ .Values.accountGuid }}",
+      "customerGUID": {{ template "account_guid" $ }},
       "clusterGUID": "",
       "clusterName": "{{ regexReplaceAll "\\W+" .Values.clusterName "-" | lower }}"
     }

--- a/charts/armo-components/templates/armo-kubescape-configmap.yaml
+++ b/charts/armo-components/templates/armo-kubescape-configmap.yaml
@@ -1,4 +1,3 @@
-{{ template "account_guid" . }}
 {{ template "cluster_name" . }}
 kind: ConfigMap 
 apiVersion: v1 
@@ -10,10 +9,10 @@ metadata:
     tier: {{ .Values.global.namespaceTier }}  
 data:
   clusterName: {{ regexReplaceAll "\\W+" .Values.clusterName "-" | lower  }}  # deprecate
-  customerGUID: {{ .Values.accountGuid }} # deprecate
+  customerGUID: {{ template "account_guid" $ }}
   config.json: |
     {
-      "customerGUID": "{{ .Values.accountGuid }}",
-      "accountID": "{{ .Values.accountGuid }}",
+      "customerGUID": {{ template "account_guid" $ }},
+      "accountID": {{ template "account_guid" $ }},
       "clusterName": "{{ regexReplaceAll "\\W+" .Values.clusterName "-" | lower  }}"
     }

--- a/charts/armo-components/templates/armo-vuln-scanner-deployment.yaml
+++ b/charts/armo-components/templates/armo-vuln-scanner-deployment.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.armoVulnScanner.enabled  }}
-{{ template "account_guid" . }}
+{{- if and .Values.armoVulnScanner.enabled .Values.accountGuid }}
 {{ template "cluster_name" . }}
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
currently the helm chart needs to be deployed with an accountGuid, although kubescape can run perfectly well without it. This PR introduces the following changes:
* disable the hard fail if accountGuid is missing in helpers.tpl, when  `.Values.armoKubescape.submit` is set to false
* add a return value for the "account_guid" template that is either the accountGuid if set or empty string
* remove the template calls to "account_guid" in most resource headers and replace references to `.Values.accountGuid` with the call to the template to insert the correct value
* omit collector and vulnerability scanner if no accountGuid is provided since those deployments go into a crashloop if not set

TBD:
in this setup, if accountGuid is set BUT  `.Values.armoKubescape.submit` is set to false, collector and vulnerability scanner are deployed and will submit results. The other solution would be to check for `.Values.armoKubescape.submit` in the header of those deployments and omit them if it is false, however, in the future we might want to use those deployments in installations that do not want to submit but e.g. scrape them with prometheus.