### PR TITLE
Add functionality to add additional volumes & volumeMounts either globally or per service

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ helm upgrade --install armo  armo/armo-cluster-components -n armo-system --creat
 | armoCollector.enabled | bool | `true` | enable/disable the armoCollector |
 | armoCollector.env[0] | object | `{"name":"PRINT_REPORT","value":"false"}` | print in verbose mode (print all reported data) |
 | armoCollector.image.repository | string | `"quay.io/armosec/cluster-collector"` | [source code](https://github.com/armosec/k8s-armo-collector) (private repo) |
+| armoCollector.volumes | object | `[]` | Additional volumes for the collector |
+| armoCollector.volumeMounts | object | `[]` | Additional volumeMounts for the collector |
 | armoKubescape.downloadArtifacts | bool | `true` | download policies every scan, we recommend it should remain true, you should change to 'false' when running in an air-gapped environment or when scanning with high frequency (when running with Prometheus) |
 | armoKubescape.enableHostScan | bool | `true` | enable [host scanner feature](https://hub.armo.cloud/docs/host-sensor) |
 | armoKubescape.enabled | bool | `true` | enable/disable kubescape scanning |
@@ -50,18 +52,32 @@ helm upgrade --install armo  armo/armo-cluster-components -n armo-system --creat
 | armoKubescape.serviceMonitor.enabled | bool | `false` | enable/disable service monitor for prometheus (operator) integration |
 | armoKubescape.skipUpdateCheck | bool | `false` | skip check for a newer version  |
 | armoKubescape.submit | bool | `true` | submit results to ARMO SaaS: https://portal.armo.cloud/ |
+| armoKubescape.volumes | object | `[]` | Additional volumes for Kubescape |
+| armoKubescape.volumeMounts | object | `[]` | Additional volumeMounts for Kubescape |
 | armoKubescapeScanScheduler.enabled | bool | `true` | enable/disable a kubescape scheduled scan using a CronJob |
 | armoKubescapeScanScheduler.image.repository | string | `"quay.io/armosec/http_request"` | [source code](https://github.com/armosec/http-request) (public repo) |
 | armoKubescapeScanScheduler.scanSchedule | string | `"0 0 * * *"` | scan schedule frequency |
+| armoKubescapeScanScheduler.volumes | object | `[]` | Additional volumes for scan scheduler |
+| armoKubescapeScanScheduler.volumeMounts | object | `[]` | Additional volumeMounts for scan scheduler |
 | armoNotificationService.enabled | bool | `true` | enable/disable passing notifications from ARMO SaaS to the armo-web-socket microservice. The notifications are the onDemand scanning and the scanning schedule settings |
 | armoNotificationService.image.repository | string | `"quay.io/armosec/notification-server"` | [source code](https://github.com/armosec/capostman) (private repo) |
+| armoNotificationService.volumes | object | `[]` | Additional volumes for the notification service |
+| armoNotificationService.volumeMounts | object | `[]` | Additional volumeMounts for the notification service |
 | armoScanScheduler.enabled | bool | `true` | enable/disable image vulnerability a schedule scan using a CronJob |
 | armoScanScheduler.image.repository | string | `"curlimages/curl"` | image: curlimages/curl |
 | armoScanScheduler.scanSchedule | string | `"0 0 * * *"` | scan schedule frequency |
+| armoKubescapeScanScheduler.volumes | object | `[]` | Additional volumes for scan scheduler |
+| armoKubescapeScanScheduler.volumeMounts | object | `[]` | Additional volumeMounts for scan scheduler |
 | armoVulnScanner.enabled | bool | `true` | enable/disable image vulnerability scanning |
 | armoVulnScanner.image.repository | string | `"quay.io/armosec/images-vulnerabilities-scan"` | [source code](https://github.com/armosec/ca-vuln-scan) (private repo) |
+| armoVulnScanner.volumes | object | `[]` | Additional volumes for the image vulnerability scanning |
+| armoVulnScanner.volumeMounts | object | `[]` | Additional volumeMounts for the image vulnerability scanning |
 | armoWebsocket.enabled | bool | `true` | enable/disable kubescape and image vulnerability scanning |
 | armoWebsocket.image.repository | string | `"quay.io/armosec/action-trigger"` | [source code](https://github.com/armosec/k8s-ca-websocket) (private repo) |
+| armoWebsocket.volumes | object | `[]` | Additional volumes for the web socket |
+| armoWebsocket.volumeMounts | object | `[]` | Additional volumeMounts for the web socket |
+| armoKubescapeHostScanner.volumes | object | `[]` | Additional volumes for the host scanner |
+| armoKubescapeHostScanner.volumeMounts | object | `[]` | Additional volumeMounts for the host scanner |
 | aws_iam_role_arn | string | `nil` | AWS IAM arn role |
 | clientID | string | `""` | client ID, [read more](https://hub.armo.cloud/docs/authentication) |
 | cloudRegion | string | `nil` | cloud region |
@@ -70,5 +86,7 @@ helm upgrade --install armo  armo/armo-cluster-components -n armo-system --creat
 | gke_service_account | string | `nil` | GKE service account |
 | secretKey | string | `""` | secret key, [read more](https://hub.armo.cloud/docs/authentication) |
 | triggerNewImageScan | string | `"disable"` | enable/disable trigger image scan for new images |
+| volumes | object | `[]` | Additional volumes for all containers |
+| volumeMounts | object | `[]` | Additional volumeMounts for all containers |
 
 

--- a/charts/armo-components/assets/armo-kubescape-cronjob-full.yaml
+++ b/charts/armo-components/assets/armo-kubescape-cronjob-full.yaml
@@ -32,12 +32,22 @@ apiVersion: batch/v1
                     mountPath: /home/armo/request-body.json
                     subPath: request-body.json
                     readOnly: true
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 18 }}
+{{- end }}
+{{- if .Values.armoKubescapeScanScheduler.volumeMounts }}
+{{ toYaml .Values.armoKubescapeScanScheduler.volumeMounts | indent 18 }}
+{{- end }}
               restartPolicy: Never
               automountServiceAccountToken: false
               volumes:
                 - name: "request-body-volume" # placeholder
                   configMap:
                     name: {{ .Values.armoKubescapeScanScheduler.name }}
- 
-
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 16 }}
+{{- end }}
+{{- if .Values.armoKubescapeScanScheduler.volumes }}
+{{ toYaml .Values.armoKubescapeScanScheduler.volumes | indent 16 }}
+{{- end }}
           

--- a/charts/armo-components/assets/host-scanner-definition.yaml
+++ b/charts/armo-components/assets/host-scanner-definition.yaml
@@ -53,6 +53,12 @@ spec:
         volumeMounts:
         - mountPath: /host_fs
           name: host-filesystem
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.armoKubescapeHostScanner.volumeMounts }}
+{{ toYaml .Values.armoKubescapeHostScanner.volumeMounts | indent 8 }}
+{{- end }}
         readinessProbe:
           httpGet:
             path: /kernelVersion
@@ -67,6 +73,12 @@ spec:
           path: /
           type: Directory
         name: host-filesystem
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.armoKubescapeHostScanner.volumes }}
+{{ toYaml .Values.armoKubescapeHostScanner.volumes | indent 6 }}
+{{- end }}
       hostNetwork: true
       hostPID: true
       hostIPC: true

--- a/charts/armo-components/templates/armo-collector-deployment.yaml
+++ b/charts/armo-components/templates/armo-collector-deployment.yaml
@@ -60,6 +60,12 @@ spec:
             - name: {{ .Values.global.beConfig }}
               mountPath: /etc/config
               readOnly: true
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 12 }}
+{{- end }}
+{{- if .Values.armoCollector.volumeMounts }}
+{{ toYaml .Values.armoCollector.volumeMounts | indent 12 }}
+{{- end }}
       volumes:
         - name: {{ .Values.global.beConfig }}
           configMap:
@@ -67,6 +73,12 @@ spec:
             items:
             - key: "clusterData"
               path: "clusterData.json"
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 8 }}
+{{- end }}
+{{- if .Values.armoCollector.volumes }}
+{{ toYaml .Values.armoCollector.volumes | indent 8 }}
+{{- end }}
       serviceAccountName: {{ .Values.global.armoServiceAccountName }}
       automountServiceAccountToken: true
       {{- with .Values.nodeSelector }}

--- a/charts/armo-components/templates/armo-kubescape-deployment.yaml
+++ b/charts/armo-components/templates/armo-kubescape-deployment.yaml
@@ -89,6 +89,12 @@ spec:
         - name: host-scanner-definition
           mountPath: /home/armo/.kubescape/host-scanner.yaml
           subPath: host-scanner-yaml
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.armoKubescape.volumeMounts }}
+{{ toYaml .Values.armoKubescape.volumeMounts | indent 8 }}
+{{- end }}
       serviceAccountName: {{ .Values.global.armoKubescapeServiceAccountName }}
       automountServiceAccountToken: true
       volumes:
@@ -98,4 +104,10 @@ spec:
       - name: host-scanner-definition
         configMap:
           name: host-scanner-definition
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.armoKubescape.volumes }}
+{{ toYaml .Values.armoKubescape.volumes | indent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/armo-components/templates/armo-kubescape-host-scanner-definition-config-map.yaml
+++ b/charts/armo-components/templates/armo-kubescape-host-scanner-definition-config-map.yaml
@@ -8,4 +8,4 @@ metadata:
     tier: {{ .Values.global.namespaceTier }}
 data:
   host-scanner-yaml: |-
-{{ .Files.Get "assets/host-scanner-definition.yaml" | indent 6 }}
+{{ tpl (.Files.Get "assets/host-scanner-definition.yaml") . | indent 4}}

--- a/charts/armo-components/templates/armo-kubescapeScanScheduler-cronjob.yaml
+++ b/charts/armo-components/templates/armo-kubescapeScanScheduler-cronjob.yaml
@@ -37,10 +37,22 @@ spec:
                 mountPath: /home/armo/request-body.json
                 subPath: request-body.json
                 readOnly: true
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 14 }}
+{{- end }}
+{{- if .Values.armoKubescapeScanScheduler.volumeMounts }}
+{{ toYaml .Values.armoKubescapeScanScheduler.volumeMounts | indent 14 }}
+{{- end }}
           restartPolicy: Never
           automountServiceAccountToken: false
           volumes:
           - name: {{ .Values.armoKubescapeScanScheduler.name }}
             configMap:
               name: {{ .Values.armoKubescapeScanScheduler.name }}
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 10 }}
+{{- end }}
+{{- if .Values.armoKubescapeScanScheduler.volumes }}
+{{ toYaml .Values.armoKubescapeScanScheduler.volumes | indent 10 }}
+{{- end }}
 {{- end }}

--- a/charts/armo-components/templates/armo-notification-service-deployment.yaml
+++ b/charts/armo-components/templates/armo-notification-service-deployment.yaml
@@ -61,6 +61,12 @@ spec:
           - name: {{ .Values.global.beConfig }}
             mountPath: /etc/config
             readOnly: true
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 10 }}
+{{- end }}
+{{- if .Values.armoNotificationService.volumeMounts }}
+{{ toYaml .Values.armoNotificationService.volumeMounts | indent 10 }}
+{{- end }}
       volumes:
         - name: {{ .Values.global.beConfig }}
           configMap:
@@ -68,6 +74,12 @@ spec:
             items:
             - key: "clusterData"
               path: "clusterData.json"
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 8 }}
+{{- end }}
+{{- if .Values.armoNotificationService.volumes }}
+{{ toYaml .Values.armoNotificationService.volumes | indent 8 }}
+{{- end }}
       automountServiceAccountToken: false
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/armo-components/templates/armo-scanScheduler-cronjob.yaml
+++ b/charts/armo-components/templates/armo-scanScheduler-cronjob.yaml
@@ -35,6 +35,12 @@ spec:
                 mountPath: /home/curl_user/trigger-script.sh
                 subPath: trigger-script.sh
                 readOnly: true
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 14 }}
+{{- end }}
+{{- if .Values.armoScanScheduler.volumeMounts }}
+{{ toYaml .Values.armoScanScheduler.volumeMounts | indent 14 }}
+{{- end }}
           restartPolicy: Never
           automountServiceAccountToken: false
           volumes:
@@ -42,4 +48,10 @@ spec:
             configMap:
               defaultMode: 0777
               name: {{ .Values.armoScanScheduler.name }}-config
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 10 }}
+{{- end }}
+{{- if .Values.armoScanScheduler.volumes }}
+{{ toYaml .Values.armoScanScheduler.volumes | indent 10 }}
+{{- end }}
 {{- end }}

--- a/charts/armo-components/templates/armo-vuln-scanner-deployment.yaml
+++ b/charts/armo-components/templates/armo-vuln-scanner-deployment.yaml
@@ -76,6 +76,12 @@ spec:
             - name: {{ .Values.global.beConfig }}
               mountPath: /etc/config
               readOnly: true
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 12 }}
+{{- end }}
+{{- if .Values.armoVulnScanner.volumeMounts }}
+{{ toYaml .Values.armoVulnScanner.volumeMounts | indent 12 }}
+{{- end }}
       volumes:
         - name: {{ .Values.global.beConfig }}
           configMap:
@@ -83,6 +89,12 @@ spec:
             items:
             - key: "clusterData"
               path: "clusterData.json"
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 8 }}
+{{- end }}
+{{- if .Values.armoVulnScanner.volumes }}
+{{ toYaml .Values.armoVulnScanner.volumes | indent 8 }}
+{{- end }}
       serviceAccountName: {{ .Values.global.armoServiceAccountName }}
       automountServiceAccountToken: true
       {{- with .Values.nodeSelector }}

--- a/charts/armo-components/templates/armo-websocket-deployment.yaml
+++ b/charts/armo-components/templates/armo-websocket-deployment.yaml
@@ -64,6 +64,12 @@ spec:
             - name: {{ .Values.global.beConfig }}
               mountPath: /etc/config
               readOnly: true
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 12 }}
+{{- end }}
+{{- if .Values.armoWebsocket.volumeMounts }}
+{{ toYaml .Values.armoWebsocket.volumeMounts | indent 12 }}
+{{- end }}
       volumes:
         - name: {{ .Values.global.beConfig }}
           configMap:
@@ -71,6 +77,12 @@ spec:
             items:
             - key: "clusterData"
               path: "clusterData.json"
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 8 }}
+{{- end }}
+{{- if .Values.armoWebsocket.volumes }}
+{{ toYaml .Values.armoWebsocket.volumes | indent 8 }}
+{{- end }}
       serviceAccountName: {{ .Values.global.armoServiceAccountName }}
       automountServiceAccountToken: true
       {{- with .Values.nodeSelector }}

--- a/charts/armo-components/values.yaml
+++ b/charts/armo-components/values.yaml
@@ -63,6 +63,12 @@ fullnameOverride: ""
 # -- enable/disable trigger image scan for new images
 triggerNewImageScan: "disable"  
 
+# Additional volumes applied to all containers
+volumes: []
+
+# Additional volumeMounts applied to all containers
+volumeMounts: []
+
 global:
   armoSystemMode: "SCAN"
   namespaceTier: armo-system-control-plane
@@ -100,6 +106,12 @@ armoScanScheduler:
 
   replicaCount: 1
 
+  # Additional volumes to be mounted on the scan scheduler
+  volumes: []
+
+  # Additional volumeMounts to be mounted on the scan scheduler
+  volumeMounts: []
+
 # kubescape scheduled scan using a CronJob
 armoKubescapeScanScheduler:
 
@@ -129,6 +141,12 @@ armoKubescapeScanScheduler:
     pullPolicy: IfNotPresent
 
   replicaCount: 1
+
+  # Additional volumes to be mounted on the scan scheduler
+  volumes: []
+
+  # Additional volumeMounts to be mounted on the scan scheduler
+  volumeMounts: []
 
 # kubescape scanner - https://github.com/armosec/kubescape
 armoKubescape:
@@ -179,6 +197,12 @@ armoKubescape:
     # If needed the service monitor can be deployed to a different namespace than the one armoKubescape is in
     #namespace: my-namespace
 
+  # Additional volumes to be mounted on Kubescape
+  volumes: []
+
+  # Additional volumeMounts to be mounted on Kubescape
+  volumeMounts: []
+
 # armoWebsocket will trigger kubescape and image vulnerability scanning
 armoWebsocket:
 
@@ -211,6 +235,12 @@ armoWebsocket:
        memory: 300Mi
   env: {}
   labels: {}
+
+  # Additional volumes to be mounted on the websocket
+  volumes: []
+
+  # Additional volumeMounts to be mounted on the websocket
+  volumeMounts: []
 
 # image vulnerability scanning microservice
 armoVulnScanner:
@@ -254,6 +284,12 @@ armoVulnScanner:
 
   labels: {}
 
+  # Additional volumes to be mounted on the vulnerability scanning microservice
+  volumes: []
+
+  # Additional volumeMounts to be mounted on the vulnerability scanning microservice
+  volumeMounts: []
+
 # armoCollector will collect the data only in the armo-system namespace and report the data to the ARMO SaaS. This is to enable onDemand scanning and for creating/editing/deleting scheduled scans from the ARMO SaaS
 armoCollector:
 
@@ -287,6 +323,12 @@ armoCollector:
 
 
   labels: {}
+
+  # Additional volumes to be mounted on the collector
+  volumes: []
+
+  # Additional volumeMounts to be mounted on the collector
+  volumeMounts: []
 
 # armoNotificationService pass notifications from ARMO SaaS to the armo-web-socket microservice. The notifications are the onDemand scanning and the scanning schedule settings
 armoNotificationService:
@@ -326,3 +368,16 @@ armoNotificationService:
 
   env: {}
   labels: {}
+
+  # Additional volumes to be mounted on the notification-service
+  volumes: []
+
+  # Additional volumeMounts to be mounted on the notification-service
+  volumeMounts: []
+
+armoKubescapeHostScanner:
+  # Additional volumes to be mounted on the Kubescape host scanner
+  volumes: []
+
+  # Additional volumeMounts to be mounted on the Kubescape host scanner
+  volumeMounts: []


### PR DESCRIPTION
This PR adds the functionality to add additional volumes and volumeMounts either globally or per service.

The reason behind this for this is that in our company we use SSL inspecting firewalls and in order to trust the certificates we need to be able to mount a new trusted CA bundle into the containers.