### PR TITLE
Add functionality to add additional volumes & volumeMounts to the new vuln scan scheduler cronjob

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ helm upgrade --install armo  armo/armo-cluster-components -n armo-system --creat
 | armoVulnScanner.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) |
 | armoVulnScanner.volumes | object | `[]` | Additional volumes for the image vulnerability scanning |
 | armoVulnScanner.volumeMounts | object | `[]` | Additional volumeMounts for the image vulnerability scanning |
+| armoVulnScanScheduler.volumes | object | `[]` | Additional volumes for scan scheduler |
+| armoVulnScanScheduler.volumeMounts | object | `[]` | Additional volumeMounts for scan scheduler |
 | armoWebsocket.affinity | object | `{}` | Assign custom [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) rules to the deployment |
 | armoWebsocket.enabled | bool | `true` | enable/disable kubescape and image vulnerability scanning |
 | armoWebsocket.image.repository | string | `"quay.io/armosec/action-trigger"` | [source code](https://github.com/armosec/k8s-ca-websocket) (private repo) |

--- a/charts/armo-components/assets/armo-vulnscan-cronjob-full.yaml
+++ b/charts/armo-components/assets/armo-vulnscan-cronjob-full.yaml
@@ -32,12 +32,22 @@ apiVersion: batch/v1
                     mountPath: /home/armo/request-body.json
                     subPath: request-body.json
                     readOnly: true
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 18 }}
+{{- end }}
+{{- if .Values.armoVulnScanScheduler.volumeMounts }}
+{{ toYaml .Values.armoVulnScanScheduler.volumeMounts | indent 18 }}
+{{- end }}
               restartPolicy: Never
               automountServiceAccountToken: false
               volumes:
                 - name: "request-body-volume" # placeholder
                   configMap:
                     name: {{ .Values.armoVulnScanScheduler.name }}
- 
-
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 16 }}
+{{- end }}
+{{- if .Values.armoVulnScanScheduler.volumes }}
+{{ toYaml .Values.armoVulnScanScheduler.volumes | indent 16 }}
+{{- end }}
           

--- a/charts/armo-components/values.yaml
+++ b/charts/armo-components/values.yaml
@@ -271,6 +271,12 @@ armoVulnScanScheduler:
 
   replicaCount: 1
 
+  # Additional volumes to be mounted on the vuln scan scheduler
+  volumes: []
+
+  # Additional volumeMounts to be mounted on the vuln scan scheduler
+  volumeMounts: []
+
 # image vulnerability scanning microservice
 armoVulnScanner:
 


### PR DESCRIPTION
Add additional volumes and volume mounts to the new vuln scan scheduler cronjob.

I added these to all the other services in PR #67, how can we ensure that these are added to new services in the future?