### PR TITLE
check enabled value when creating vuln scanner config map

### DIFF
--- a/charts/armo-components/templates/armo-vulnscan-recurring-cronjob-config-map.yaml
+++ b/charts/armo-components/templates/armo-vulnscan-recurring-cronjob-config-map.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.armoVulnScanner.enabled .Values.armoKubescape.submit }}
 kind: ConfigMap 
 apiVersion: v1 
 metadata:
@@ -9,3 +10,4 @@ metadata:
 data:
   cronjobTemplate: |-
     {{ tpl (.Files.Get "assets/armo-vulnscan-cronjob-full.yaml") . }}
+{{- end }}


### PR DESCRIPTION
The vulnscan-cronjob-template ConfigMap is a part of vuln scanner resources, but it doesn't check `.Values.armoVulnScanner.enabled` and `.Values.armoKubescape.submit`.